### PR TITLE
Fix ie and safari detection

### DIFF
--- a/lib/detect/browser.js
+++ b/lib/detect/browser.js
@@ -1024,7 +1024,7 @@ var detect = function (win, userAgent) {
 		} else {
 			browserType = TYPE.UNKNOWN_MOBILE;
 		}
-	} else if (!has('Notification', w) && (!has('EventSource', w) && can(nav, 'onLine')) ) {
+	} else if (!has('EventSource', w) && can(nav, 'onLine')) {
 		browserType = TYPE.MICROSOFT;
 	} else if (has('InstallTrigger', w)) {
 		browserType = TYPE.FIREFOX;
@@ -1032,7 +1032,7 @@ var detect = function (win, userAgent) {
 		browserType = TYPE.CHROME;
 	} else if (has('opera', w) || looksLike(/\sOPR\/\d+/i, ua)) {
 		browserType = TYPE.OPERA;
-	} else if (!has('webkitRequestFileSystem', w) && !has('Intl', w)) {
+	} else if (!has('webkitRequestFileSystem', w)) {
 		browserType = TYPE.SAFARI;
 	} else {
 		browserType = TYPE.UNKNOWN;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adlibs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A collection of common client side commonjs modules",
   "scripts": {
     "test": "karma start --single-run",
@@ -18,8 +18,7 @@
   ],
   "author": "Conversant Media",
   "license": "Apache-2.0",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "coveralls": "^2.11.9",
     "expect.js": "^0.3.1",


### PR DESCRIPTION
The next versions of IE/Edge and Safari will support window.Internalization and window.notification, respectively. This would break our current browser detection. Removing the check for those features still provides accurate results when ran through Sauce Labs tests.